### PR TITLE
Remove blanking the first column, some refactoring

### DIFF
--- a/attiny_scroll.ino
+++ b/attiny_scroll.ino
@@ -32,15 +32,14 @@ void loop()
 {
 
   // Setup scroll...
-  OzOled.setDeactivateScroll(); 
-  OzOled.setCursorXYPixel(0,0);
-  OzOled.sendData(0); // blank first column for wrap
-  OzOled.setCursorXYPixel(0,1);
-  OzOled.sendData(0); // blank first column for wrap
-  OzOled.setCursorXYPixel(126,0);
-  OzOled.sendBiggerCharData(message[messagei],fontcolumn); // top half
-  OzOled.setCursorXYPixel(126,1);
-  OzOled.sendBiggerCharData(message[messagei],fontcolumn+12); // lower half
+  OzOled.setDeactivateScroll();
+  OzOled.scrollLeftPixel(0, 1, 8); // Perform hardware scroll
+  OzOled.setDeactivateScroll();  // End... moved 1 pixel?
+
+  OzOled.setCursorXYPixel(127, 0);
+  OzOled.sendBiggerCharData(message[messagei], fontcolumn); // top half
+  OzOled.setCursorXYPixel(127, 1);
+  OzOled.sendBiggerCharData(message[messagei], fontcolumn + 12); // lower half
 
   if (++fontcolumn == 12) { // increment character index?
     fontcolumn = 0;
@@ -49,11 +48,7 @@ void loop()
     }
   }
 
-  
-  OzOled.scrollLeftPixel(0,1,8); // Perform hardware scroll
-  OzOled.setDeactivateScroll();  // End... moved 1 pixel?
-  
-  delay(10); 
+  delay(10);
 
   //perform other functions while scrolling stopped
 

--- a/attiny_scroll.ino
+++ b/attiny_scroll.ino
@@ -41,12 +41,12 @@ void loop()
   OzOled.sendBiggerCharData(message[messagei],fontcolumn); // top half
   OzOled.setCursorXYPixel(126,1);
   OzOled.sendBiggerCharData(message[messagei],fontcolumn+12); // lower half
-  fontcolumn++; fontcolumn%=12; // column
 
-  if (fontcolumn==0)   // increment character index?
-  {
-    messagei++;
-    messagei%=message.length(); // roll over
+  if (++fontcolumn == 12) { // increment character index?
+    fontcolumn = 0;
+    if (++messagei == message.length()) { // roll over
+      messagei = 0;
+    }
   }
 
   


### PR DESCRIPTION
Without blanking the first column (0) it will be transferred to the last column (127) and immediately overwritten. I don't expect any visual artifacts. That should also utilize the two rightmost columns, otherwise writing data into column 126 and scrolling it left to 125 always leaves columns 126 and 127 blank.
Also I replaced roll over with modulo with explicit comparison. I imagine compare is cheaper (computationally and byte count wise) than division.
What do you think?